### PR TITLE
Fix pandas pandas error in [24]

### DIFF
--- a/section-2-data-science-and-ml-tools/pandas-exercises-solutions.ipynb
+++ b/section-2-data-science-and-ml-tools/pandas-exercises-solutions.ipynb
@@ -1204,7 +1204,7 @@
    ],
    "source": [
     "# Group columns of the car sales DataFrame by the Make column and find the average\n",
-    "car_sales.groupby([\"Make\"]).mean()"
+    "car_sales.groupby([\"Make\"]).mean(numeric_only=True)"
    ]
   },
   {
@@ -1308,7 +1308,7 @@
    "source": [
     "Why didn't it work? Can you think of a solution?\n",
     "\n",
-    "You might want to search for \"how to convert a pandas string columb to numbers\".\n",
+    "You might want to search for \"how to convert a pandas string column to numbers\".\n",
     "\n",
     "And if you're still stuck, check out this [Stack Overflow question and answer on turning a price column into integers](https://stackoverflow.com/questions/44469313/price-column-object-to-int-in-pandas).\n",
     "\n",


### PR DESCRIPTION
Updated `In [24]` for pandas error -- `mean()` requires `numeric_only=True`.

Plus correct a spelling error.